### PR TITLE
Add initial structure

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - '6'
+  - '5'

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # frontpress-cli
+
 CLI tool for FrontPress
+
+## Install
+
+```
+$ npm install --global frontpress-cli
+```
+
+## Tests
+
+```
+$ npm test
+```

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+'use strict';
+const meow = require('meow');
+const frontpressCli = require('./');
+
+const cli = meow(`
+  Usage
+    $ frontpress-cli [input]
+
+  Options
+    --foo  Lorem ipsum [Default: false]
+
+  Examples
+    $ frontpress-cli
+    Lorem ipsum
+`);
+
+console.log(frontpressCli(cli.input[0] || ''));

--- a/index.js
+++ b/index.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = (input, opts) => {
+  if (typeof input !== 'string') {
+    throw new TypeError(`Expected a string, got ${typeof input}`);
+  }
+
+  opts = opts || {};
+
+  return input + ' & ' + (opts.postfix || 'more');
+};

--- a/license
+++ b/license
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) Alison Monteiro <alisonmonteiro.10@gmail.com> (github.com/frontpressorg/frontpress-cli)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/license
+++ b/license
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) Alison Monteiro <alisonmonteiro.10@gmail.com> (github.com/frontpressorg/frontpress-cli)
+Copyright (c) Teles <josetelesmaciel@gmail.com> (github.com/frontpressorg/frontpress-cli)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -2,13 +2,40 @@
   "name": "frontpress-cli",
   "version": "0.0.0",
   "description": "CLI tool for FrontPress",
-  "main": "index.js",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/frontpressorg/frontpress-cli.git"
   },
   "author": "Teles <josetelesmaciel@gmail.com>",
-  "license": "MIT",
+  "bin": "cli.js",
+  "engines": {
+    "node": ">=5"
+  },
+  "scripts": {
+    "test": "xo && ava"
+  },
+  "files": [
+    "index.js",
+    "cli.js"
+  ],
+  "keywords": [
+    "cli-app",
+    "cli",
+    "fronpress",
+    "wordpress",
+    "angular"
+  ],
+  "dependencies": {
+    "meow": "^3.7.0"
+  },
+  "devDependencies": {
+    "ava": "^0.15.2",
+    "xo": "^0.16.0"
+  },
+  "xo": {
+    "esnext": true
+  },
   "bugs": {
     "url": "https://github.com/frontpressorg/frontpress-cli/issues"
   },

--- a/test.js
+++ b/test.js
@@ -1,0 +1,6 @@
+import test from 'ava';
+import fn from './';
+
+test('title', t => {
+  t.is(fn('test'), 'test & more');
+});


### PR DESCRIPTION
This PR adds a simple but functional structure.

- .editorconfig
- .gitignore
- travis.yml
- license
- tests + linter (using [ava](https://github.com/avajs/ava) and [xo](https://github.com/sindresorhus/xo))

Hope you guys like it.

// @teles 
